### PR TITLE
Handle SHA workflow refs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,6 +145,11 @@ runs:
             WORKFLOW_REF=$GITHUB_HEAD_REF
             echo "matching refs/pull/*/merge: $WORKFLOW_REF"
             ;;
+          [[:xdigit:]]{8,})
+            # sha hashes
+            echo "matching sha: $WORKFLOW_FULL_REF"
+            WORKFLOW_REF=$WORKFLOW_FULL_REF
+            ;;
           *)
             echo "unknown workflow ref format: $WORKFLOW_FULL_REF"
             exit 1


### PR DESCRIPTION
When pinning an action using a SHA (e.g., `use: actions/checkout@ac1e3a3508410234994a98e5f346e4a7f4bdcee8`), the `WORKFLOW_FULL_REF` comes out as the SHA only (e.g., `ac1e3a3508410234994a98e5f346e4a7f4bdcee8`). Not sure if this case used to be handled by the first case (the `ref/heads/*` one) and the format changed recently, or if pinning to a commit hash was never tested.
This PR adds a case for handling commit hashes, and also a default case which makes the action fail if the reference could not be extracted.